### PR TITLE
Feat/add account

### DIFF
--- a/MoneyManagement App/Application/MoneyManagement_AppApp.swift
+++ b/MoneyManagement App/Application/MoneyManagement_AppApp.swift
@@ -14,7 +14,7 @@ struct MoneyManagement_AppApp: App {
     
     init() {
         do {
-            container = try ModelContainer(for: User.self, BankAccount.self, Method.self)
+            container = try ModelContainer(for: User.self, BankAccount.self, Method.self, Account.self)
         } catch {
             fatalError("Failed to create ModelContainer.")
         }

--- a/MoneyManagement App/View/Views/AddAccount/AddAccountView.swift
+++ b/MoneyManagement App/View/Views/AddAccount/AddAccountView.swift
@@ -1,11 +1,99 @@
 import SwiftUI
+import SwiftData
 
 struct AddAccountView: View {
+//    var account : Account?
+    //@ObservedObject var vm : AddAccountViewModel
+    @Environment(\.dismiss) var dismiss
+    
+    @Binding var accountName : String
+    @Binding var isCreditCard : Bool
+    @Binding var invoiceClosing : Int
+    @State var showAlertDiscard : Bool = false
+    //var account : Account?
+    var bankAccount : BankAccount
+    let modelContext : ModelContext
+    
+    let action : () -> Void
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            Spacer()
+            
+            HStack {
+                Text("Nome")
+                    .padding(.trailing)
+                TextField("Conta poupança", text: $accountName)
+                
+                if !accountName.isEmpty {
+                    Button {
+                        accountName = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .padding()
+            .background(Color.backgroundColorRow)
+            .padding(.bottom)
+            
+            VStack {
+                Toggle("Criar como cartão de crédito", isOn: $isCreditCard)
+                if isCreditCard {
+                    Divider()
+                    //DatePicker("", selection: $vm.invoiceClosing, in: Date() ... Date.distantFuture, displayedComponents: .date)
+                      //  .datePickerStyle(.compact)
+                    
+                    HStack {
+                        Text("Dia do fechamento da fatura")
+                        Spacer()
+                        TextField("0", value: $invoiceClosing, formatter: NumberFormatter())
+                            .keyboardType(.numberPad)
+                            .frame(width: 30, alignment: .trailing)
+                    }
+                }
+            }
+            .padding()
+            .background(Color.backgroundColorRow)
+            
+            Spacer()
+        }
+        .background(Color.background)
+        .navigationTitle("Adicionar conta")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            
+            ToolbarItem(placement: .topBarLeading) {
+                Button ("Voltar") {
+                    showAlertDiscard = !(accountName.isEmpty)
+                }
+                
+            }
+            
+            
+            ToolbarItem(placement: .topBarTrailing) {
+                Button ("Salvar") {
+                    action()
+                }
+            }
+        }
+        .alert("Tem certeza de que deseja descartar estas alterações", isPresented: $showAlertDiscard) {
+            
+            Button("Descartar Alterações", role: .destructive) {
+                dismiss()
+            }
+            
+            Button("Continuar Editando", role: .cancel) {}
+            .fontWeight(.bold)
+        }
     }
 }
 
-#Preview {
-    AddAccountView()
-}
+/*
+ #Preview {
+ NavigationStack {
+ //AddAccountView(account: nil)
+ }
+ }
+ */

--- a/MoneyManagement App/View/Views/AddAccount/AddAccountView.swift
+++ b/MoneyManagement App/View/Views/AddAccount/AddAccountView.swift
@@ -2,15 +2,11 @@ import SwiftUI
 import SwiftData
 
 struct AddAccountView: View {
-//    var account : Account?
-    //@ObservedObject var vm : AddAccountViewModel
     @Environment(\.dismiss) var dismiss
-    
     @Binding var accountName : String
     @Binding var isCreditCard : Bool
     @Binding var invoiceClosing : Int
     @State var showAlertDiscard : Bool = false
-    //var account : Account?
     var bankAccount : BankAccount
     let modelContext : ModelContext
     
@@ -42,9 +38,6 @@ struct AddAccountView: View {
                 Toggle("Criar como cartão de crédito", isOn: $isCreditCard)
                 if isCreditCard {
                     Divider()
-                    //DatePicker("", selection: $vm.invoiceClosing, in: Date() ... Date.distantFuture, displayedComponents: .date)
-                      //  .datePickerStyle(.compact)
-                    
                     HStack {
                         Text("Dia do fechamento da fatura")
                         Spacer()
@@ -89,11 +82,3 @@ struct AddAccountView: View {
         }
     }
 }
-
-/*
- #Preview {
- NavigationStack {
- //AddAccountView(account: nil)
- }
- }
- */

--- a/MoneyManagement App/View/Views/AddAccount/AddAccountViewModel.swift
+++ b/MoneyManagement App/View/Views/AddAccount/AddAccountViewModel.swift
@@ -1,1 +1,6 @@
 import Foundation
+import SwiftData
+
+@Observable
+class AddAccountViewModel : ObservableObject {
+}

--- a/MoneyManagement App/View/Views/BankAccount/BankAccountView.swift
+++ b/MoneyManagement App/View/Views/BankAccount/BankAccountView.swift
@@ -72,7 +72,6 @@ struct BankAccountView: View {
                         } else {
                             LazyVGrid(columns: [GridItem(), GridItem(), GridItem()], spacing: 20) {
                                 ForEach(creditCards) { account in
-                                    bankAccountVM.cleanInputs()
                                     BankAccountViewAccount(account: account)
                                 }
                             }
@@ -85,6 +84,7 @@ struct BankAccountView: View {
                             Spacer()
                             // TODO: Adioncar conta
                             Button(action: {
+                                bankAccountVM.cleanInputs()
                                 bankAccountVM.presentAddAccountView = true
                             }) {
                                 Image(systemName: "plus")

--- a/MoneyManagement App/View/Views/BankAccount/BankAccountView.swift
+++ b/MoneyManagement App/View/Views/BankAccount/BankAccountView.swift
@@ -71,7 +71,9 @@ struct BankAccountView: View {
                                 .padding([.top, .leading])
                             Spacer()
                             // TODO: Adioncar conta
-                            Button(action: {  }) {
+                            Button(action: {
+                                bankAccountVM.presentAddAccountView = true
+                            }) {
                                 Image(systemName: "plus")
                             }
                             .padding([.top, .trailing])
@@ -121,6 +123,14 @@ struct BankAccountView: View {
                 self.bankAccountVM.deleteBankAccount()
                 self.dismiss()
             })
+        }
+        .sheet(isPresented: $bankAccountVM.presentAddAccountView) {
+            NavigationStack {
+                AddAccountView(accountName: $bankAccountVM.accountName, isCreditCard: $bankAccountVM.isCreditCard, invoiceClosing: $bankAccountVM.closeDay, bankAccount: self.bankAccountVM.bankAccount, modelContext: self.bankAccountVM.modelContext) {
+                    bankAccountVM.appendAccount()
+                }
+            }
+            .presentationDetents([.medium])
         }
     }
     

--- a/MoneyManagement App/View/Views/BankAccount/BankAccountView.swift
+++ b/MoneyManagement App/View/Views/BankAccount/BankAccountView.swift
@@ -10,6 +10,14 @@ struct BankAccountView: View {
         self.bankAccountVM = BankAccountViewModel(modelContext: modelContext, bankAccount: bankAccount)
     }
     
+    @Query(filter: #Predicate<Account> { account in
+        account.isCreditCard == true
+    }, sort: \Account.name) var creditCards: [Account]
+    
+    @Query(filter: #Predicate<Account> { account in
+        account.isCreditCard == false
+    }, sort: \Account.name) var accounts: [Account]
+    
     var body: some View {
         NavigationStack{
             ZStack (alignment: .top) {
@@ -43,12 +51,16 @@ struct BankAccountView: View {
                                 .padding([.top, .leading])
                             Spacer()
                             // TODO: Adioncar cartão de crédito
-                            Button(action: {  }) {
+                            Button(action: {
+                                bankAccountVM.cleanInputs()
+                                bankAccountVM.isCreditCard = true
+                                bankAccountVM.presentAddAccountView = true
+                            }) {
                                 Image(systemName: "plus")
                             }
                             .padding([.top, .trailing])
                         }
-                        if(bankAccountVM.creditCards.isEmpty){
+                        if(creditCards.isEmpty){
                             HStack (alignment: .center) {
                                 Text("Não possui cartões de créditos")
                                     .font(.title3)
@@ -59,7 +71,8 @@ struct BankAccountView: View {
                             .frame(maxWidth: .infinity, minHeight: 130)
                         } else {
                             LazyVGrid(columns: [GridItem(), GridItem(), GridItem()], spacing: 20) {
-                                ForEach(bankAccountVM.accounts) { account in
+                                ForEach(creditCards) { account in
+                                    bankAccountVM.cleanInputs()
                                     BankAccountViewAccount(account: account)
                                 }
                             }
@@ -78,7 +91,7 @@ struct BankAccountView: View {
                             }
                             .padding([.top, .trailing])
                         }
-                        if(bankAccountVM.accounts.isEmpty){
+                        if(accounts.isEmpty){
                             HStack (alignment: .center) {
                                 Text("Não possui contas")
                                     .font(.title3)
@@ -89,7 +102,7 @@ struct BankAccountView: View {
                             .frame(maxWidth: .infinity, minHeight: 130)
                         } else {
                             LazyVGrid(columns: [GridItem(), GridItem(), GridItem()], spacing: 20) {
-                                ForEach(bankAccountVM.accounts) { account in
+                                ForEach(accounts) { account in
                                     BankAccountViewAccount(account: account)
                                 }
                             }

--- a/MoneyManagement App/View/Views/BankAccount/BankAccountViewModel.swift
+++ b/MoneyManagement App/View/Views/BankAccount/BankAccountViewModel.swift
@@ -7,8 +7,6 @@ class BankAccountViewModel: ObservableObject {
     // SwiftData
     let modelContext: ModelContext
     var bankAccount: BankAccount
-    //var creditCards: [Account] = []
-    //var accounts: [Account] = []
     // Entrada de Dados
     var bankAccountName: String = ""
     var accountName : String = ""
@@ -24,27 +22,6 @@ class BankAccountViewModel: ObservableObject {
         self.bankAccountName = self.bankAccount.name
     }
     
-    /*
-    
-    func fetchCreditCards() {
-        do {
-            self.creditCards = try modelContext.fetch(FetchDescriptor<Account>(sortBy: [.init(\.name)]))
-        } catch {
-            print("Deu ruim 1")
-        }
-    }
-    
-    func fetchAccounts() {
-        do {
-            let accountsFetched = try modelContext.fetch(FetchDescriptor<Account>(sortBy: [.init(\.name)]))
-            accounts.removeAll()
-            accounts.append(contentsOf: accountsFetched)
-        } catch {
-            print("Deu ruim 1")
-        }
-    }
-    */
-     
     func setNameBankAccount() {
         self.bankAccount.name = self.bankAccountName
         do {

--- a/MoneyManagement App/View/Views/BankAccount/BankAccountViewModel.swift
+++ b/MoneyManagement App/View/Views/BankAccount/BankAccountViewModel.swift
@@ -7,15 +7,13 @@ class BankAccountViewModel: ObservableObject {
     // SwiftData
     let modelContext: ModelContext
     var bankAccount: BankAccount
-    var creditCards: [Account] = []
-    var accounts: [Account] = []
+    //var creditCards: [Account] = []
+    //var accounts: [Account] = []
     // Entrada de Dados
     var bankAccountName: String = ""
     var accountName : String = ""
     var isCreditCard : Bool = false
-    var closeDay : Int = 0
-    // Dados para visualização
-    
+    var closeDay : Int = 0    
     // Booleans para visualização
     var isShowingBankEdit: Bool = false
     var presentAddAccountView = false
@@ -25,6 +23,8 @@ class BankAccountViewModel: ObservableObject {
         self.bankAccount = bankAccount
         self.bankAccountName = self.bankAccount.name
     }
+    
+    /*
     
     func fetchCreditCards() {
         do {
@@ -36,12 +36,15 @@ class BankAccountViewModel: ObservableObject {
     
     func fetchAccounts() {
         do {
-            self.accounts = try modelContext.fetch(FetchDescriptor<Account>(sortBy: [.init(\.name)]))
+            let accountsFetched = try modelContext.fetch(FetchDescriptor<Account>(sortBy: [.init(\.name)]))
+            accounts.removeAll()
+            accounts.append(contentsOf: accountsFetched)
         } catch {
             print("Deu ruim 1")
         }
     }
-    
+    */
+     
     func setNameBankAccount() {
         self.bankAccount.name = self.bankAccountName
         do {
@@ -62,9 +65,7 @@ class BankAccountViewModel: ObservableObject {
     
     func appendAccount () {
         let account = Account(idUser: self.bankAccount.idUser, name: self.accountName)
-        
-        print("arguments: \(self.accountName), \(isCreditCard), \(closeDay)")
-        
+                
         self.modelContext.insert(account)
         
         if self.isCreditCard {
@@ -75,15 +76,17 @@ class BankAccountViewModel: ObservableObject {
         do {
             try self.modelContext.save()
         } catch {
-            print("Deu ruim 2")
+            print("Deu ruim")
         }
-        self.fetchAccounts()
         
+        cleanInputs()
         
-        //accounts.append(account)
         presentAddAccountView = false
-        
-        
     }
     
+    func cleanInputs () {
+        self.bankAccountName = ""
+        self.isCreditCard = false
+        self.closeDay = 1
+    }
 }

--- a/MoneyManagement App/View/Views/BankAccount/BankAccountViewModel.swift
+++ b/MoneyManagement App/View/Views/BankAccount/BankAccountViewModel.swift
@@ -11,10 +11,14 @@ class BankAccountViewModel: ObservableObject {
     var accounts: [Account] = []
     // Entrada de Dados
     var bankAccountName: String = ""
+    var accountName : String = ""
+    var isCreditCard : Bool = false
+    var closeDay : Int = 0
     // Dados para visualização
     
     // Booleans para visualização
     var isShowingBankEdit: Bool = false
+    var presentAddAccountView = false
     
     init(modelContext: ModelContext, bankAccount: BankAccount) {
         self.modelContext = modelContext
@@ -54,6 +58,32 @@ class BankAccountViewModel: ObservableObject {
         } catch {
             print("Deu ruim 1")
         }
+    }
+    
+    func appendAccount () {
+        let account = Account(idUser: self.bankAccount.idUser, name: self.accountName)
+        
+        print("arguments: \(self.accountName), \(isCreditCard), \(closeDay)")
+        
+        self.modelContext.insert(account)
+        
+        if self.isCreditCard {
+            account.isCreditCard = true
+            account.closeDay = closeDay
+        }
+        
+        do {
+            try self.modelContext.save()
+        } catch {
+            print("Deu ruim 2")
+        }
+        self.fetchAccounts()
+        
+        
+        //accounts.append(account)
+        presentAddAccountView = false
+        
+        
     }
     
 }

--- a/MoneyManagement App/View/Views/Home/HomeView.swift
+++ b/MoneyManagement App/View/Views/Home/HomeView.swift
@@ -114,18 +114,19 @@ struct HomeView: View {
         }
         .sheet(isPresented: self.$homeVM.isShowingScreenNameUser, content: {
             UserForm(name: self.$homeVM.personName, formState: .create, action: self.homeVM.appendUser)
-                .sheet(isPresented: self.$homeVM.isShowingScreenNameUser, content: {
-                    UserForm(name: self.$homeVM.personName, formState: .create, action: self.homeVM.appendUser)
-                })
-                .sheet(isPresented: self.$homeVM.isShowingScreenNameBankAccount, content: {
-                    FinancialInstitueForm(bankName: self.$homeVM.bankAccountName, originalName: self.homeVM.bankAccountName, formState: .create, action: self.homeVM.appendBankAccount)
-                })
-                .alert("Tem certeza de que deseja descartar esta nova Instituição Financeira?", isPresented: $homeVM.isShowingBankCancellationAlert) {
-                    Button("Descartar Alterações", role: .cancel) {  }
-                    Button("Continuar Editando", role: .destructive) {  }
-                        .tint(.blue)
-                }
+                
         })
+        .sheet(isPresented: self.$homeVM.isShowingScreenNameUser, content: {
+            UserForm(name: self.$homeVM.personName, formState: .create, action: self.homeVM.appendUser)
+        })
+        .sheet(isPresented: self.$homeVM.isShowingScreenNameBankAccount, content: {
+            FinancialInstitueForm(bankName: self.$homeVM.bankAccountName, originalName: self.homeVM.bankAccountName, formState: .create, action: self.homeVM.appendBankAccount)
+        })
+        .alert("Tem certeza de que deseja descartar esta nova Instituição Financeira?", isPresented: $homeVM.isShowingBankCancellationAlert) {
+            Button("Descartar Alterações", role: .cancel) {  }
+            Button("Continuar Editando", role: .destructive) {  }
+                .tint(.blue)
+        }
     }
 }
 

--- a/MoneyManagement App/View/Views/Home/HomeViewModel.swift
+++ b/MoneyManagement App/View/Views/Home/HomeViewModel.swift
@@ -33,7 +33,7 @@ class HomeViewModel : ObservableObject {
         } catch {
             print("Deu ruim 1")
         }
-    }
+    }//
     
     func fetchBankAccounts() {
         do {

--- a/MoneyManagement App/View/Views/Home/HomeViewModel.swift
+++ b/MoneyManagement App/View/Views/Home/HomeViewModel.swift
@@ -33,7 +33,7 @@ class HomeViewModel : ObservableObject {
         } catch {
             print("Deu ruim 1")
         }
-    }//
+    }
     
     func fetchBankAccounts() {
         do {


### PR DESCRIPTION
### Issue
closes #49

### Overview
Essa PR inclui uma View que permite que o usuário consiga adicionar novas contas dentro de contas bancárias, contém 3 campos, o campo de nome da conta, se é uma conta de cartão de crédito ou não, e se sim, quando a conta vence, eu integrei essa view com o que já foi criado na BankAccountView.

### Key Changes

- **Add account**: Agora você pode preencher um formulário para adicionar uma nova conta.
- **integração com BankAccountView**: Agora a BankAccountView pode acessar a AddAccountView e criar novas contas, que serão dispostas em duas seções, a de cartão de crédito e a de outras contas.